### PR TITLE
Bug fix and Compatibility

### DIFF
--- a/capstone-app/src/app/app.component.html
+++ b/capstone-app/src/app/app.component.html
@@ -9,11 +9,13 @@
 <app-map
   (activeMarkerOutput)="updateActiveMarker($event)"
   (markerDataOutput)="updateMarkerData($event)"
-  (cityOutput)="cityUpdate($event)">
+  (cityOutput)="cityUpdate($event)"
+  [activeMark] = "activeMarker">
 </app-map>
 <app-photos-section 
   [city]="city" 
   [markerPlaces]="markerData"
-  [activeMarker]="activeMarker">
+  [activeMarker]="activeMarker"
+  (activeMarkerUpdate)="updateActiveMarker($event)">
 </app-photos-section>
 <app-wiki-media-history-section [cityName]="city"></app-wiki-media-history-section>

--- a/capstone-app/src/app/app.component.ts
+++ b/capstone-app/src/app/app.component.ts
@@ -6,7 +6,7 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  title = 'capstone-app';
+  title = 'GMapr';
   activeMarker: string;
   city: string;
   markerData = new Map<string, string[]>();

--- a/capstone-app/src/app/modules/maps/map/map.component.spec.ts
+++ b/capstone-app/src/app/modules/maps/map/map.component.spec.ts
@@ -1,12 +1,14 @@
 /// <reference types="googlemaps" />
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MapComponent } from './map.component';
-import { GoogleMapsModule } from '@angular/google-maps';
+import { GoogleMapsModule, MapMarker } from '@angular/google-maps';
 import { By } from '@angular/platform-browser';
+import { SimpleChange, SimpleChanges } from '@angular/core';
 
 // due to flaky testing sometimes these tests will fail due to undefined markers or map centers
 describe('MapComponent', () => {
   let fixture: ComponentFixture<MapComponent>;
+  let component: MapComponent;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -18,6 +20,7 @@ describe('MapComponent', () => {
 
   beforeEach(() => {
     fixture = TestBed.createComponent(MapComponent);
+    component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
@@ -43,6 +46,19 @@ describe('MapComponent', () => {
     const markerComponent = markerDebug.map(marker => marker.componentInstance.getPosition());
 
     expect(markerComponent).toEqual(fixture.componentInstance.markers.map(marker => marker.position));
+  });
+
+
+  it('opens new info window when receives new active marker', () => {
+    spyOn(component, 'getMarkerFromTitle');
+    let holder: MapMarker;
+    component.allMarkers = [holder, holder];
+    const changesObj: SimpleChanges = {
+      activeMark: new SimpleChange('', 'State House', false)
+    };
+    component.activeMark = 'State House';
+    component.ngOnChanges(changesObj);
+    expect(component.getMarkerFromTitle).toHaveBeenCalledWith(component.activeMark);
   });
 
   // TODO: fix flaky testing issue
@@ -120,7 +136,6 @@ describe('MapComponent', () => {
 
     expect(searchMarkers).toEqual(coordinates);
   });
-  
   // TODO: fix flaky testing issue
   // sometimes will fail do to an undefined map center just refresh until it passs
   it('sets center and zoom of the map', () => {

--- a/capstone-app/src/app/modules/maps/map/map.component.ts
+++ b/capstone-app/src/app/modules/maps/map/map.component.ts
@@ -55,13 +55,13 @@ export class MapComponent implements OnInit, OnChanges {
         this.infoWindow.close();
       }
       else if (this.allMarkers) {
-          this.infoWindowMarker = this.getMarkerFromTitle(this.activeMark);
-          if (this.infoWindowMarker) {
-            this.openInfoWindow(this.infoWindowMarker);
-          }
-          else {
-            this.infoWindow.close();
-          }
+        this.infoWindowMarker = this.getMarkerFromTitle(this.activeMark);
+        if (this.infoWindowMarker) {
+          this.openInfoWindow(this.infoWindowMarker);
+        }
+        else {
+          this.infoWindow.close();
+        }
       }
     }
   }

--- a/capstone-app/src/app/modules/maps/map/map.component.ts
+++ b/capstone-app/src/app/modules/maps/map/map.component.ts
@@ -54,8 +54,7 @@ export class MapComponent implements OnInit, OnChanges {
       if (change.activeMark.currentValue === '') {
         this.infoWindow.close();
       }
-      else {
-        if (this.allMarkers) {
+      else if (this.allMarkers) {
           this.infoWindowMarker = this.getMarkerFromTitle(this.activeMark);
           if (this.infoWindowMarker) {
             this.openInfoWindow(this.infoWindowMarker);
@@ -63,7 +62,6 @@ export class MapComponent implements OnInit, OnChanges {
           else {
             this.infoWindow.close();
           }
-        }
       }
     }
   }

--- a/capstone-app/src/app/modules/photos/components/image-container/image-container.component.spec.ts
+++ b/capstone-app/src/app/modules/photos/components/image-container/image-container.component.spec.ts
@@ -87,18 +87,4 @@ describe('ImageContainerComponent', () => {
     component.ngOnChanges(changesObj);
     expect(component.filter).toBe('');
   });
-
-  it('filter should be active marker when there exists a current active marker', () => {
-    component.city = 'Boston';
-    component.ngOnChanges({});
-    expect(component.query).toBe('Boston early 1900s');
-    component.filter = 'Aquarium';
-    component.ngOnChanges({});
-    expect(component.query).toBe('Boston Aquarium');
-    component.activeMarker = 'Tea Party';
-    component.ngOnChanges({
-      activeMarker: new SimpleChange('Tea Party', '', false)
-    });
-    expect(component.query).toBe('Boston Tea Party');
-  });
 });

--- a/capstone-app/src/app/modules/photos/components/image-container/image-container.component.ts
+++ b/capstone-app/src/app/modules/photos/components/image-container/image-container.component.ts
@@ -24,7 +24,6 @@ export class ImageContainerComponent implements OnChanges, OnInit {
   @Input() city!: string;
   @Input() filter?: string;
   @Input() limit = 10;
-  @Input() activeMarker?: string;
   @Output() limitChange = new EventEmitter<LimitChange>();
   displayPhotos: Photo[] = [];
   originalPhotos: Photo[] = [];
@@ -42,13 +41,10 @@ export class ImageContainerComponent implements OnChanges, OnInit {
     if (changes.city) {
       this.filter = '';
     }
-    else if (changes.activeMarker) {
-      this.filter = this.activeMarker;
-    }
     this.query = this.filter
       ? `${this.city} ${this.filter}`
       : `${this.city} early 1900s`;
-    if (changes.city || changes.filter || changes.activeMarker) {
+    if (changes.city || changes.filter) {
       this.getPhotos();
     }
     this.limitPhotos(this.limit);

--- a/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.html
+++ b/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.html
@@ -41,6 +41,5 @@
   [filter]="markerFilter"
   [limit]="limitControl.value"
   [city]="city"
-  [activeMarker]="activeMarker"
   (limitChange)="updateLimit($event.max, $event.wasRemoved)"
 ></app-image-container>

--- a/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.spec.ts
+++ b/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.spec.ts
@@ -9,7 +9,7 @@ import { of } from 'rxjs';
 import { PhotosSectionComponent } from './photos-section.component';
 import { PhotoFetcher } from '../../services/photo-fetcher.service';
 import { By } from '@angular/platform-browser';
-import { DebugElement, SimpleChanges, SimpleChange } from '@angular/core';
+import { SimpleChanges, SimpleChange } from '@angular/core';
 import { MatButtonHarness } from '@angular/material/button/testing';
 import { NavItem } from '../../nav-item';
 import { MatMenuHarness } from '@angular/material/menu/testing';
@@ -81,15 +81,26 @@ describe('PhotosSectionComponent', () => {
     expect(component.uniqueTypes).toEqual(expectedUniqueTypes);
   });
 
-  it('active marker should be blank if city or filter changes', () => {
+  it('active marker should reset if city or filter changes', () => {
+    spyOn(component.activeMarkerUpdate, 'emit');
     component.city = 'Boston';
     component.markerPlaces = testMarkerPlaces;
     component.activeMarker = 'Aquarium';
-    const changesObjNonActive: SimpleChanges = {
-      city: new SimpleChange('Boston', 'Philly', false)
+    component.updateFilterSelected('State House');
+    expect(component.activeMarkerUpdate.emit).toHaveBeenCalled();
+  });
+
+  it('filter should be active marker if active marker selected', () => {
+    component.city = 'Boston';
+    component.markerPlaces = testMarkerPlaces;
+    component.updateFilterSelected('Aquarium');
+    expect(component.markerFilter).toBe('Aquarium');
+    component.activeMarker = 'State House';
+    const changesObj: SimpleChanges = {
+      activeMarker: new SimpleChange('Aquarium', 'State House', false)
     };
-    component.ngOnChanges(changesObjNonActive);
-    expect(component.activeMarker).toEqual('');
+    component.ngOnChanges(changesObj);
+    expect(component.markerFilter).toBe('State House');
   });
 
   it('should ouput the value of the limit', async () => {

--- a/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.ts
+++ b/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.ts
@@ -4,6 +4,8 @@ import {
   OnChanges,
   SimpleChanges,
   OnInit,
+  Output,
+  EventEmitter,
 } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { NavItem } from '../../nav-item';
@@ -17,6 +19,7 @@ export class PhotosSectionComponent implements OnInit, OnChanges {
   @Input() city: string;
   @Input() markerPlaces: Map<string, string[]>;
   @Input() activeMarker: string;
+  @Output() activeMarkerUpdate = new EventEmitter<string>();
   previousCity: string;
   limitControl = new FormControl(10, [Validators.min(1), Validators.max(10)]);
   maxPhotos = 10;
@@ -41,12 +44,12 @@ export class PhotosSectionComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     if (changes.city && this.city === '') {
       this.city = this.previousCity;
-    } else {
-      this.previousCity = this.city;
     }
-
-    if (!changes.activeMarker) {
-      this.activeMarker = '';
+    else if (changes.activeMarker) {
+      this.markerFilter = this.activeMarker;
+    }
+    else {
+      this.previousCity = this.city;
     }
 
     this.extractUniqueTypes();
@@ -101,6 +104,7 @@ export class PhotosSectionComponent implements OnInit, OnChanges {
   }
 
   updateFilterSelected(newFilter: string) {
+    this.activeMarkerUpdate.emit(newFilter);
     if (newFilter !== this.city) {
       this.markerFilter = newFilter;
     } else {


### PR DESCRIPTION
This PR accomplishes a few important things:
1) Fixes bug where if a user clicks on a marker on the map then clicks on the city name in the filter, photos do not change
2) Adds increased compatibility between maps and photos as now if a user selects a filter in the photos section, the corresponding marker opens a new info window
3) The info window is closed when the user selects the city name