### PR TITLE
Photos bug02

### DIFF
--- a/capstone-app/src/app/app.component.html
+++ b/capstone-app/src/app/app.component.html
@@ -8,13 +8,10 @@
 </h1>
 <app-map
   (activeMarkerOutput)="updateActiveMarker($event)"
-  (markerDataOutput)="updateMarkerData($event)"
   (cityOutput)="cityUpdate($event)"
   [activeMark] = "activeMarker">
 </app-map>
 <app-photos-section 
-  [city]="city" 
-  [markerPlaces]="markerData"
   [activeMarker]="activeMarker"
   (activeMarkerUpdate)="updateActiveMarker($event)">
 </app-photos-section>

--- a/capstone-app/src/app/app.component.ts
+++ b/capstone-app/src/app/app.component.ts
@@ -9,14 +9,9 @@ export class AppComponent {
   title = 'GMapr';
   activeMarker: string;
   city: string;
-  markerData = new Map<string, string[]>();
 
   updateActiveMarker(newActiveMarker: string) {
     this.activeMarker = newActiveMarker;
-  }
-
-  updateMarkerData(newMarker: Map<string, string[]>) {
-    this.markerData = newMarker;
   }
 
   cityUpdate(newCity: string) {

--- a/capstone-app/src/app/modules/maps/map/map.component.html
+++ b/capstone-app/src/app/modules/maps/map/map.component.html
@@ -1,4 +1,3 @@
-
 <span class="buttons">
   <div class ="search-box">
     <mat-form-field class="search-bar">

--- a/capstone-app/src/app/modules/maps/map/map.component.ts
+++ b/capstone-app/src/app/modules/maps/map/map.component.ts
@@ -1,3 +1,4 @@
+import { SharedPlacesCityService } from 'src/app/services/shared-places-city.service';
 import { OnChanges, SimpleChanges, Input, ViewChildren } from '@angular/core';
 /// <reference types="googlemaps" />
 import { Component,  ViewChild, ElementRef, OnInit, Output, EventEmitter, ChangeDetectorRef } from '@angular/core';
@@ -17,8 +18,6 @@ export class MapComponent implements OnInit, OnChanges {
 
   @Input() activeMark: string;
   @Output() activeMarkerOutput = new EventEmitter<string>();
-  @Output() markerDataOutput = new EventEmitter<Map<string, string[]>>();
-  @Output() cityOutput = new EventEmitter<string>();
 
   // allMarkers: MapMarker[] = [];
   infoWindowMarker: MapMarker;
@@ -40,7 +39,7 @@ export class MapComponent implements OnInit, OnChanges {
     type: 'tourist_attraction'
   };
 
-  constructor(private readonly changeDetector: ChangeDetectorRef) {}
+  constructor(private readonly changeDetector: ChangeDetectorRef, private placesSerice: SharedPlacesCityService) {}
 
   ngOnInit() {
     this.getCurrentOrSetLocation();
@@ -73,9 +72,10 @@ export class MapComponent implements OnInit, OnChanges {
       {fields: ['geometry', 'name', 'formatted_address'], types: ['(cities)']});
     autoComplete.addListener('place_changed', () => {
       this.location = autoComplete.getPlace().geometry.location;
+      this.changeDetector.markForCheck();
       this.cityLocation = autoComplete.getPlace().formatted_address;
       this.placesRequestFunc(this.location);
-      this.cityOutput.emit(this.cityLocation);
+      this.placesSerice.setCityName(this.cityLocation);
     });
   }
 
@@ -90,7 +90,7 @@ export class MapComponent implements OnInit, OnChanges {
         this.markerData.set(result.name, result.types);
       }
       this.changeDetector.markForCheck();
-      this.markerDataOutput.emit(this.markerData);
+      this.placesSerice.setPlaces(this.markerData);
     });
   }
 
@@ -113,9 +113,10 @@ export class MapComponent implements OnInit, OnChanges {
   // gets our default location
   getCurrentOrSetLocation() {
     if (!this.location) {
-      this.cityLocation = "Los Angeles, CA, USA"
+      this.cityLocation = "Los Angeles, CA, USA";
       this.location = new google.maps.LatLng(34.0522, -118.2437);
-      this.cityOutput.emit(this.cityLocation);
+      this.changeDetector.markForCheck();
+      this.placesSerice.setCityName(this.cityLocation);
     }
   }
 

--- a/capstone-app/src/app/modules/maps/map/map.component.ts
+++ b/capstone-app/src/app/modules/maps/map/map.component.ts
@@ -39,7 +39,7 @@ export class MapComponent implements OnInit, OnChanges {
     type: 'tourist_attraction'
   };
 
-  constructor(private readonly changeDetector: ChangeDetectorRef, private placesSerice: SharedPlacesCityService) {}
+  constructor(private readonly changeDetector: ChangeDetectorRef, private placeCitySharer: SharedPlacesCityService) {}
 
   ngOnInit() {
     this.getCurrentOrSetLocation();
@@ -75,7 +75,7 @@ export class MapComponent implements OnInit, OnChanges {
       this.changeDetector.markForCheck();
       this.cityLocation = autoComplete.getPlace().formatted_address;
       this.placesRequestFunc(this.location);
-      this.placesSerice.setCityName(this.cityLocation);
+      this.placeCitySharer.setCityName(this.cityLocation);
     });
   }
 
@@ -90,7 +90,7 @@ export class MapComponent implements OnInit, OnChanges {
         this.markerData.set(result.name, result.types);
       }
       this.changeDetector.markForCheck();
-      this.placesSerice.setPlaces(this.markerData);
+      this.placeCitySharer.setPlaces(this.markerData);
     });
   }
 
@@ -116,7 +116,7 @@ export class MapComponent implements OnInit, OnChanges {
       this.cityLocation = "Los Angeles, CA, USA";
       this.location = new google.maps.LatLng(34.0522, -118.2437);
       this.changeDetector.markForCheck();
-      this.placesSerice.setCityName(this.cityLocation);
+      this.placeCitySharer.setCityName(this.cityLocation);
     }
   }
 

--- a/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.spec.ts
+++ b/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.spec.ts
@@ -1,6 +1,6 @@
 import { PhotosModule } from './../../photos.module';
 import { ImageContainerComponent } from './../image-container/image-container.component';
-import { async, ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatInputHarness } from '@angular/material/input/testing';
 import { HarnessLoader } from '@angular/cdk/testing';
 import MockTestImages from 'testing/mock-image-response.json';

--- a/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.spec.ts
+++ b/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.spec.ts
@@ -57,7 +57,6 @@ describe('PhotosSectionComponent', () => {
     testMarkerPlaces.set('Colonial Theater', ['History', 'Entertainment']);
     testMarkerPlaces.set('Valley Forge', ['History', 'Landmark']);
 
-
     const placesService = jasmine.createSpyObj('SharedPlacesCityService', ['getPlacesSource', 'getCityName']);
     const photosService = jasmine.createSpyObj('PhotoFetcher', ['getPhotos']);
     citySpy = placesService.getCityName.and.returnValue(of('Boston'));

--- a/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.ts
+++ b/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.ts
@@ -1,3 +1,4 @@
+import { SharedPlacesCityService } from 'src/app/services/shared-places-city.service';
 import {
   Component,
   Input,
@@ -6,9 +7,11 @@ import {
   OnInit,
   Output,
   EventEmitter,
+  ChangeDetectorRef,
 } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { NavItem } from '../../nav-item';
+import { combineLatest } from 'rxjs';
 
 @Component({
   selector: 'app-photos-section',
@@ -16,11 +19,10 @@ import { NavItem } from '../../nav-item';
   styleUrls: ['./photos-section.component.scss'],
 })
 export class PhotosSectionComponent implements OnInit, OnChanges {
-  @Input() city: string;
-  @Input() markerPlaces: Map<string, string[]>;
   @Input() activeMarker: string;
   @Output() activeMarkerUpdate = new EventEmitter<string>();
-  previousCity: string;
+  city: string;
+  markerPlaces: Map<string, string[]>;
   limitControl = new FormControl(10, [Validators.min(1), Validators.max(10)]);
   maxPhotos = 10;
   mockPlaces = new Map<string, string[]>();
@@ -34,26 +36,26 @@ export class PhotosSectionComponent implements OnInit, OnChanges {
   navItems: NavItem[] = [];
   markerFilter = '';
 
+  constructor(private readonly cd: ChangeDetectorRef, private places: SharedPlacesCityService) { }
+
   ngOnInit() {
     this.mockPlaces.set('Pjs Wings', ['Restuarant']);
     this.mockPlaces.set('Colonial Theater', ['History', 'Entertainment']);
     this.mockPlaces.set('Valley Forge', ['History', 'Landmark']);
+    combineLatest([this.places.getPlacesSource(), this.places.getCityName()]).subscribe(results => {
+      this.markerPlaces = results[0];
+      this.city = results[1];
+      if (results[0]) {
+        this.extractUniqueTypes();
+        this.populateNavItems();
+      }
+    });
   }
 
-  // Until the photos section is connected to the maps, only mocks are supported
   ngOnChanges(changes: SimpleChanges) {
-    if (changes.city && this.city === '') {
-      this.city = this.previousCity;
-    }
-    else if (changes.activeMarker) {
+    if (changes.activeMarker) {
       this.markerFilter = this.activeMarker;
     }
-    else {
-      this.previousCity = this.city;
-    }
-
-    this.extractUniqueTypes();
-    this.populateNavItems();
   }
 
   /**

--- a/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.ts
+++ b/capstone-app/src/app/modules/photos/components/photos-section/photos-section.component.ts
@@ -7,7 +7,6 @@ import {
   OnInit,
   Output,
   EventEmitter,
-  ChangeDetectorRef,
 } from '@angular/core';
 import { FormControl, Validators } from '@angular/forms';
 import { NavItem } from '../../nav-item';
@@ -36,16 +35,16 @@ export class PhotosSectionComponent implements OnInit, OnChanges {
   navItems: NavItem[] = [];
   markerFilter = '';
 
-  constructor(private readonly cd: ChangeDetectorRef, private places: SharedPlacesCityService) { }
+  constructor(private places: SharedPlacesCityService) { }
 
   ngOnInit() {
     this.mockPlaces.set('Pjs Wings', ['Restuarant']);
     this.mockPlaces.set('Colonial Theater', ['History', 'Entertainment']);
     this.mockPlaces.set('Valley Forge', ['History', 'Landmark']);
-    combineLatest([this.places.getPlacesSource(), this.places.getCityName()]).subscribe(results => {
-      this.markerPlaces = results[0];
-      this.city = results[1];
-      if (results[0]) {
+    combineLatest([this.places.getPlacesSource(), this.places.getCityName()]).subscribe(([placesSource, citySource]) => {
+      this.markerPlaces = placesSource;
+      this.city = citySource;
+      if (placesSource) {
         this.extractUniqueTypes();
         this.populateNavItems();
       }

--- a/capstone-app/src/app/services/shared-places-city.service.spec.ts
+++ b/capstone-app/src/app/services/shared-places-city.service.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed, getTestBed } from '@angular/core/testing';
+import { SharedPlacesCityService } from './shared-places-city.service';
+
+describe('SharedPlacesCityService', () => {
+  let service: SharedPlacesCityService;
+  let injector: TestBed;
+  const testMarkerPlaces = new Map<string, string[]>();
+
+  beforeEach(() => {
+    testMarkerPlaces.set('Pjs Wings', ['Restaurant']);
+    testMarkerPlaces.set('Colonial Theater', ['History', 'Entertainment']);
+    testMarkerPlaces.set('Valley Forge', ['History', 'Landmark']);
+
+    TestBed.configureTestingModule({
+      providers: [SharedPlacesCityService],
+    });
+    injector = getTestBed();
+    service = TestBed.inject(SharedPlacesCityService);
+  });
+
+  it('set should change cityName, get should return cityName', () => {
+    service.setCityName('Boston');
+    service.getCityName().subscribe(result => {
+      expect(result).toBe('Boston');
+    });
+  });
+
+  it('set should change markerPlaces, get should return markerPlaces', () => {
+    service.setPlaces(testMarkerPlaces);
+    service.getPlacesSource().subscribe(result => {
+      expect(result).toBe(testMarkerPlaces);
+    });
+  });
+});

--- a/capstone-app/src/app/services/shared-places-city.service.ts
+++ b/capstone-app/src/app/services/shared-places-city.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SharedPlacesCityService {
+  private cityName = new BehaviorSubject<string>(null);
+  private placesSource = new BehaviorSubject<Map<string, string[]>>(null);
+
+  setPlaces(newPlaces: Map<string, string[]>) {
+    this.placesSource.next(newPlaces);
+  }
+
+  setCityName(newCity: string) {
+    this.cityName.next(newCity);
+  }
+
+  getCityName() {
+    return this.cityName.asObservable();
+  }
+
+  getPlacesSource() {
+    return this.placesSource.asObservable();
+  }
+}


### PR DESCRIPTION
This PR accomplishes a few things:
1) It fixes the bug where sometimes the photo filters displayed the markers of the previous city by now using a shared service of behavior subject
2) In doing so, much of the logic of photos-section.component is simplified as there are no longer complex nested if statements in ngOnChanges or weird variables such as previousCity and previousMarkers
3) There is now a consistent behavior across the app for change detection. You click the click then the magnifying glass to search.